### PR TITLE
STRIPES-907 yarn v4 🔥 🚀 

### DIFF
--- a/.github/workflows/ui-install-and-lint.yml
+++ b/.github/workflows/ui-install-and-lint.yml
@@ -34,14 +34,17 @@ jobs:
           check-latest: true
           always-auth: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: yarn config set npmScopes.folio.npmRegistryServer ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: yarn install
 
       - name: List installed FOLIO package versions
-        run: yarn list --pattern @folio
+        run: yarn info --name-only @folio/\*
 
       - name: Publish yarn.lock
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ui-module-descriptor-generate.yml
+++ b/.github/workflows/ui-module-descriptor-generate.yml
@@ -32,29 +32,34 @@ jobs:
           check-latest: true
           always-auth: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: yarn config set npmScopes.folio.npmRegistryServer ${{ inputs.folio-npm-registry }}
 
-      - id: get-version
-        name: Get current @folio/stripes-cli version
-        # some packages may not specify @folio/stripes-cli as a dependency (e.g. stripes itself)
-        # in this case, we default to @latest
-        run: echo version=$(jq -r '.devDependencies["@folio/stripes-cli"]' package.json | sed s/null/latest/)
-
-      # we do it this way to avoid installing all modules
-      - name: Install @folio/stripes-cli
-        run: |-
-          rm package.json
-          yarn add @folio/stripes-cli@${{ steps.get-version.outputs.version }}
-          git checkout package.json
-
+      # note that we use `npm pkg set version` instead of `yarn version` here.
+      # tldr: https://github.com/yarnpkg/berry/issues/4548
+      # long version: 'yarn version' does a lot of work installing dependencies
+      # (which we are explicitly trying to avoid), and interacting with git in
+      # a way I don't totally understand but which leads to an error:
+      #   Usage Error: No ancestor could be found between any of HEAD and
+      #   master, origin/master, upstream/master, main, origin/main,
+      #   upstream/main
+      # Anyway. We just want to tweak the version in `package.json` and we can
+      # do that with `npm pkg`, so we do.
       - name: Set package version number to ${{ inputs.package-version }}
         run: |-
-          yarn config set version-git-tag false
-          yarn version --new-version ${{ inputs.package-version }}
+          npm pkg set version=${{ inputs.package-version }}
 
       - name: Generate module descriptor
-        run: yarn --silent stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json
+        run: |-
+          # some repositories use .stripesclirc to configure mirage for BTOG.
+          # that's all well and good, but we're not running tests here, and
+          # these customizations interfere @folio/stripes-cli's ability to
+          # locate its dependencies when we run it via `dlx`.
+          rm .stripesclirc.js
+          yarn dlx -q @folio/stripes-cli mod descriptor --full --strict | jq '.[]' > module-descriptor.json
 
       - name: Print module descriptor
         run: cat module-descriptor.json

--- a/.github/workflows/ui-publish-module.yml
+++ b/.github/workflows/ui-publish-module.yml
@@ -46,11 +46,16 @@ jobs:
           check-latest: true
           always-auth: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set FOLIO NPM registry
-        run: npm config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: yarn config set npmScopes.folio.npmRegistryServer ${{ inputs.folio-npm-registry }}
 
       - name: Authenticate to FOLIO NPM registry
-        run: npm config set ${{ inputs.folio-npm-registry-auth }}:_auth ${{ secrets.npm-token }}
+        run: |-
+          yarn config set npmScopes.folio.npmAlwaysAuth true
+          yarn config set npmScopes.folio.npmAuthToken ${{ secrets.npm-token }}
 
       - name: Download module descriptor
         if: ${{ inputs.module-descriptor-available }}
@@ -75,10 +80,19 @@ jobs:
       - name: Print package exclusions
         run: cat .npmignore
 
+      # note that we use `npm pkg set version` instead of `yarn version` here.
+      # tldr: https://github.com/yarnpkg/berry/issues/4548
+      # long version: 'yarn version' does a lot of work installing dependencies
+      # (which we are explicitly trying to avoid), and interacting with git in
+      # a way I don't totally understand but which leads to an error:
+      #   Usage Error: No ancestor could be found between any of HEAD and
+      #   master, origin/master, upstream/master, main, origin/main,
+      #   upstream/main
+      # Anyway. We just want to tweak the version in `package.json` and we can
+      # do that with `npm pkg`, so we do.
       - name: Set package version number to ${{ inputs.package-version }}
         run: |-
-          yarn config set version-git-tag false
-          yarn version --new-version ${{ inputs.package-version }}
+          npm pkg set version=${{ inputs.package-version }}
 
       - name: Publish package
         run: npm publish

--- a/.github/workflows/ui-tests-bigtest.yml
+++ b/.github/workflows/ui-tests-bigtest.yml
@@ -38,11 +38,14 @@ jobs:
           check-latest: true
           always-auth: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: yarn config set npmScopes.folio.npmRegistryServer ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: yarn install
 
       - name: Run Bigtest tests
         run: ${{ inputs.bigtest-test-command }}
@@ -68,4 +71,4 @@ jobs:
         with:
           name: yarn.lock
           path: yarn.lock
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/ui-tests-jest.yml
+++ b/.github/workflows/ui-tests-jest.yml
@@ -38,11 +38,14 @@ jobs:
           check-latest: true
           always-auth: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: yarn config set npmScopes.folio.npmRegistryServer ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: yarn install
 
       - name: Run Jest tests
         run: ${{ inputs.jest-test-command }}
@@ -72,4 +75,4 @@ jobs:
         with:
           name: yarn.lock
           path: yarn.lock
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/ui-translations.yml
+++ b/.github/workflows/ui-translations.yml
@@ -29,22 +29,20 @@ jobs:
           check-latest: true
           always-auth: true
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
-
-      - id: get-version
-        name: Get current @folio/stripes-cli version
-        run: echo version=$(jq -r '.devDependencies["@folio/stripes-cli"]' package.json)
-
-      # we do it this way to avoid installing all modules
-      - name: Install @folio/stripes-cli
-        run: |-
-          rm package.json
-          yarn add @folio/stripes-cli@${{ steps.get-version.outputs.version }}
-          git checkout package.json
+        run: yarn config set npmScopes.folio.npmRegistryServer ${{ inputs.folio-npm-registry }}
 
       - name: Compile translations
-        run: yarn stripes translate compile
+        run: |-
+          # some repositories use .stripesclirc to configure mirage for BTOG.
+          # that's all well and good, but we're not running tests here, and
+          # these customizations interfere @folio/stripes-cli's ability to
+          # locate its dependencies when we run it via `dlx`.
+          rm .stripesclirc.js
+          yarn dlx @folio/stripes-cli translate compile
 
       - name: Publish translations
         uses: actions/upload-artifact@v4

--- a/README-UI.md
+++ b/README-UI.md
@@ -4,6 +4,7 @@
 - [Versioning](#versioning)
 - [Using in your repository](#using-in-your-repository)
   - [Yarn v4](#yarn-v4)
+    - [Windows shenanigans](#windows-shenanigans)
   - [Yarn v1 (deprecated)](#yarn-v1)
 - [Configuration](#configuration)
   - [Node/Yarn configuration](#nodeyarn-configuration)
@@ -64,6 +65,17 @@ git rm .npmrc
 yarn add -D jest@^29 jest-environment-jsdom@^29
 git add package.json .yarnrc.yml yarn.lock .yarn/releases
 ```
+
+#### Windows shenanigans
+
+Windows users, note [this `corepack` bug](https://github.com/nodejs/corepack/issues/334) and [manual workaround](https://github.com/nodejs/corepack/issues/334#issuecomment-1906658423): the `yarn set version berry` step will fail with `Internal Error: ENOENT: no such file or directory, stat 'C:\Users\{username}\AppData\Local\node\corepack\yarn\{yarn version}'`. The work around is:
+* In an admin console powershell, run `corepack enable` then `corepack disable`. This will create `C:\Users\{username}\AppData\Local\node\corepack`.
+* In Windows Explorer go to `C:\Users\{username}\AppData\Local\node\corepack`. There will be one or more directories named `corepack-xxxx-xxxxxxxxxx`. Open one and copy the two files (`yarn.js`, `.corepack`).
+* In Windows Explorer go to `C:\Users\{username}\AppData\Local\node\corepack\yarn`. Create a new directory corresponding to your `yarn` version, e.g. `4.1.1` and paste the two files.
+* In an admin console powershell, run `corepack enable`
+* In a non-admin console powershell, in your project directory, run `corepack prepare yarn@stable --activate`
+* To confirm this was successful, run `yarn -v`; you should see something like `4.1.1`.
+
 
 ### yarn v1 (deprecated)
 Be sure your workflow specifies `v1` of this repository:

--- a/README-UI.md
+++ b/README-UI.md
@@ -61,6 +61,7 @@ If you are migrating from yarn v1, follow [yarn's v4 migration guide](https://ya
 corepack enable
 yarn set version berry
 yarn config set npmScopes.folio.npmRegistryServer https://repository.folio.org/repository/npm-folioci/
+yarn config set nodeLinker node-modules
 git rm .npmrc
 yarn add -D jest@^29 jest-environment-jsdom@^29
 git add package.json .yarnrc.yml yarn.lock .yarn/releases

--- a/README-UI.md
+++ b/README-UI.md
@@ -56,9 +56,10 @@ jobs:
     secrets: inherit
 ```
 
-If you are migrating from yarn v1, follow [yarn's v4 migration guide](https://yarnpkg.com/migration/guide), steps which are automated and customized for our build infrastructure in [this small shell script](https://gist.github.com/zburke/eb68b91506145185360b14aa6dcf9922). At minimum:
+If you are migrating from yarn v1, follow [yarn's v4 migration guide](https://yarnpkg.com/migration/guide), steps which are automated and customized for our build infrastructure in [this small bash script](https://gist.github.com/zburke/eb68b91506145185360b14aa6dcf9922). Mac/Linux users should be able to run it as is; Windows users will need to run it like `bash yarn-v4.sh`. To perform the minimal steps manually:
 ```sh
 corepack enable
+corepack prepare yarn@4.1.1
 yarn set version berry
 yarn config set npmScopes.folio.npmRegistryServer https://repository.folio.org/repository/npm-folioci/
 yarn config set nodeLinker node-modules
@@ -66,17 +67,19 @@ git rm .npmrc
 yarn add -D jest@^29 jest-environment-jsdom@^29
 git add package.json .yarnrc.yml yarn.lock .yarn/releases
 ```
+This will download v4 binaries and make them available but will leave 1.x as your default for projects that haven't specifically chosen to upgrade to v4.
 
 #### Windows shenanigans
 
-Windows users, note [this `corepack` bug](https://github.com/nodejs/corepack/issues/334) and [manual workaround](https://github.com/nodejs/corepack/issues/334#issuecomment-1906658423): the `yarn set version berry` step will fail with `Internal Error: ENOENT: no such file or directory, stat 'C:\Users\{username}\AppData\Local\node\corepack\yarn\{yarn version}'`. The work around is:
+Windows users, note [this `corepack` bug](https://github.com/nodejs/corepack/issues/334) and [manual workaround](https://github.com/nodejs/corepack/issues/334#issuecomment-1906658423): the `yarn set version berry` step will fail with `Internal Error: ENOENT: no such file or directory, stat 'C:\Users\{username}\AppData\Local\node\corepack\yarn\{yarn version}'`. Corepack on Windows is fussy but the following steps seem to allow v1 and v4 to peacefully coexist.
+
 * In an admin console powershell, run `corepack enable` then `corepack disable`. This will create `C:\Users\{username}\AppData\Local\node\corepack`.
 * In Windows Explorer go to `C:\Users\{username}\AppData\Local\node\corepack`. There will be one or more directories named `corepack-xxxx-xxxxxxxxxx`. Open one and copy the two files (`yarn.js`, `.corepack`).
 * In Windows Explorer go to `C:\Users\{username}\AppData\Local\node\corepack\yarn`. Create a new directory corresponding to your `yarn` version, e.g. `4.1.1` and paste the two files.
 * In an admin console powershell, run `corepack enable`
-* In a non-admin console powershell, in your project directory, run `corepack prepare yarn@stable --activate`
+* In a non-admin console powershell, in your project directory, run `yarn set verion berry`
 * To confirm this was successful, run `yarn -v`; you should see something like `4.1.1`.
-
+* To switch to v1 in another project, run `yarn set version 1.22`. Contrary to the documentation, `yarn set version latest` does not work.
 
 ### yarn v1 (deprecated)
 The `.github/workflows/ui.yml` file is identical to that specified above except that it references `v1` of this repository:

--- a/README-UI.md
+++ b/README-UI.md
@@ -3,6 +3,8 @@
 - [Methodology](#methodology)
 - [Versioning](#versioning)
 - [Using in your repository](#using-in-your-repository)
+  - [Yarn v4](#yarn-v4)
+  - [Yarn v1 (deprecated)](#yarn-v1)
 - [Configuration](#configuration)
   - [Node/Yarn configuration](#nodeyarn-configuration)
   - [Linting](#linting)
@@ -35,10 +37,9 @@ This project uses semver, similar to how other FOLIO modules currently operate. 
 
 To use the centralized workflow, create a `.github/workflows` directory in the root of your repository. If it exists already, replace the `build-npm.yml` and `build-npm-release.yml` with a single file, e.g. `ui.yml`, with the following content:
 
-### yarn v1
+### yarn v4
 
 ```yaml
-# todo: better name?
 name: Centralized workflow
 on:
   - push
@@ -48,19 +49,27 @@ on:
 jobs:
   ui:
     # Use the shared workflow from https://github.com/folio-org/.github
-    uses: folio-org/.github/.github/workflows/ui.yml@v1
+    uses: folio-org/.github/.github/workflows/ui.yml@v2
     # Only handle push events from the main branch, to decrease noise
     if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
     secrets: inherit
 ```
-### yarn v4
 
-Be sure your workflow specifies `v2` of this repository:
-```yaml
-uses: folio-org/.github/.github/workflows/ui.yml@v2
+If you are migrating from yarn v1, follow [yarn's v4 migration guide](https://yarnpkg.com/migration/guide), steps which are automated and customized for our build infrastructure in [this small shell script](https://gist.github.com/zburke/eb68b91506145185360b14aa6dcf9922). At minimum:
+```sh
+corepack enable
+yarn set version berry
+yarn config set npmScopes.folio.npmRegistryServer https://repository.folio.org/repository/npm-folioci/
+git rm .npmrc
+yarn add -D jest@^29 jest-environment-jsdom@^29
+git add package.json .yarnrc.yml yarn.lock .yarn/releases
 ```
-and follow [yarn's v4 migration guide](https://yarnpkg.com/migration/guide), steps which are automated and customized for our build infrastructure in [this small shell script](https://gist.github.com/zburke/eb68b91506145185360b14aa6dcf9922).
 
+### yarn v1 (deprecated)
+Be sure your workflow specifies `v1` of this repository:
+```yaml
+uses: folio-org/.github/.github/workflows/ui.yml@v1
+```
 
 ## Configuration
 

--- a/README-UI.md
+++ b/README-UI.md
@@ -79,7 +79,7 @@ Windows users, note [this `corepack` bug](https://github.com/nodejs/corepack/iss
 
 
 ### yarn v1 (deprecated)
-Be sure your workflow specifies `v1` of this repository:
+The `.github/workflows/ui.yml` file is identical to that specified above except that it references `v1` of this repository:
 ```yaml
 uses: folio-org/.github/.github/workflows/ui.yml@v1
 ```

--- a/README-UI.md
+++ b/README-UI.md
@@ -29,18 +29,18 @@ Solid arrows indicate jobs that must succeed for the next job to run. Dashed arr
 
 ## Versioning
 
-This project will use semver, similar to how other FOLIO modules currently operate.
-When specifying the version of these workflows that you want to use, it is recommended to use the latest major version only, so that new minor/patch releases are automatically picked up.
+This project uses semver, similar to how other FOLIO modules currently operate. Use the major version only, so new minor/patch releases are automatically picked up. Use `v1` for yarn v1; use `v2` for yarn v4.
 
 ## Using in your repository
 
-To use the centralized workflow in your repository, you need to create a `.github/workflows` directory in the root of your repository, and add a file `ui.yml` with the following content:
+To use the centralized workflow, create a `.github/workflows` directory in the root of your repository. If it exists already, replace the `build-npm.yml` and `build-npm-release.yml` with a single file, e.g. `ui.yml`, with the following content:
+
+### yarn v1
 
 ```yaml
 # todo: better name?
-name: Centralized workflow test
+name: Centralized workflow
 on:
-  # todo: what would be best here?
   - push
   - pull_request
   - workflow_dispatch
@@ -53,10 +53,14 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
     secrets: inherit
 ```
+### yarn v4
 
-And that's it! Now your repository will use the centralized workflow.
+Be sure your workflow specifies `v2` of this repository:
+```yaml
+uses: folio-org/.github/.github/workflows/ui.yml@v2
+```
+and follow [yarn's v4 migration guide](https://yarnpkg.com/migration/guide), steps which are automated and customized for our build infrastructure in [this small shell script](https://gist.github.com/zburke/eb68b91506145185360b14aa6dcf9922).
 
-Once you have the new workflow added and everything appears to work, it is safe to delete the old workflows (`build-npm.yml` and similar).
 
 ## Configuration
 


### PR DESCRIPTION
Yarn. Taste it again for the first time.
One small step for a devloper. One giant leap for devloperkind. 
Yarn v4. It's not your father's dependency manager. 
Steven Tyler: Yarn this way!
Darryl McDaniels: Yarn this way!

Most changes are straightforward tweaks to handle the differences between v1 and v4, with a few exceptions:
* instead of hacking `package.json` in the the "compile translation" and "generate MD" steps to avoid installing anything except stripes-cli, we just run it remotely via `yarn dlx`, the yarn equivalent of `npx`. 
* `yarn version` was substantially overhauled in v4 and no longer does what we need; `npm pkg set version` retains its original behavior and is used here instead.

[Corresponding PR in stripes-core](https://github.com/folio-org/stripes-core/pull/1458) 

[STRIPES-907](https://folio-org.atlassian.net/browse/STRIPES-907)