### PR TITLE
Deploy on non-mainline tags

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -261,8 +261,8 @@ jobs:
 
   okapi-dependency-check:
     name: Okapi dependency check (main branch only)
-    needs: [generate-module-descriptor]
-    if: ${{ inputs.generate-module-descriptor && startsWith(github.ref, 'refs/tags/v') }}
+    needs: [set-shared-variables, generate-module-descriptor]
+    if: ${{ inputs.generate-module-descriptor && needs.set-shared-variables.outputs.is-release == 'True' }}
     uses: ./.github/workflows/ui-module-descriptor-verify.yml
     with:
       okapi-pull-contents: '{"urls": ["https://folio-registry.dev.folio.org"]}'
@@ -272,13 +272,13 @@ jobs:
 
   publish-module-descriptor:
     name: Publish module descriptor (main branch only)
-    needs: [generate-module-descriptor, okapi-dependency-check]
-    # okapi-dependency-check is optional, but if it's enabled, we want to require it (for tag releases)
+    needs: [set-shared-variables, generate-module-descriptor, okapi-dependency-check]
+    # okapi-dependency-check is optional, but if it's enabled, we want to require it for tag releases
     if: |
       !cancelled() &&
       inputs.publish-module-descriptor &&
       (needs.okapi-dependency-check.result == 'success' || needs.okapi-dependency-check.result == 'skipped') &&
-      github.ref_name == github.event.repository.default_branch
+      (github.ref_name == github.event.repository.default_branch || needs.set-shared-variables.outputs.is-release == 'True')
     uses: ./.github/workflows/ui-module-descriptor-publish.yml
     with:
       module-descriptor-registry: ${{ inputs.module-descriptor-registry }}
@@ -309,7 +309,7 @@ jobs:
       (needs.translations.result == 'success' || needs.translations.result == 'skipped') &&
       (needs.jest-tests.result == 'success' || needs.jest-tests.result == 'skipped') &&
       (needs.bigtest-tests.result == 'success' || needs.bigtest-tests.result == 'skipped') &&
-      github.ref_name == github.event.repository.default_branch
+      (github.ref_name == github.event.repository.default_branch || needs.set-shared-variables.outputs.is-release == 'True')
 
     uses: ./.github/workflows/ui-publish-module.yml
     with:


### PR DESCRIPTION
This fixes a logic error which caused tags to go unpublished if added to non-mainline branches (e.g. `b1.0`).