### PR TITLE
STRIPES-907 modern workflows with modern npm

### DIFF
--- a/.github/workflows/ui-install-and-lint.yml
+++ b/.github/workflows/ui-install-and-lint.yml
@@ -3,7 +3,7 @@ name: FOLIO UI Install Packages
 on:
   workflow_call:
     inputs:
-      # yarn configuration
+      # npm configuration
       node-version:
         required: true
         type: string
@@ -35,23 +35,23 @@ jobs:
           always-auth: true
 
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: npm config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: npm install --ignore-scripts
 
       - name: List installed FOLIO package versions
-        run: yarn list --pattern @folio
+        run: npm ls | grep @folio
 
-      - name: Publish yarn.lock
+      - name: Publish package-lock.json
         uses: actions/upload-artifact@v4
         with:
-          name: yarn.lock
-          path: yarn.lock
-          retention-days: 1
+          name: package-lock.json
+          path: package-lock.json
+          retention-days: 7
 
       # TODO: something like https://github.com/marketplace/actions/lint-action would be cool
       # Particularly as we consider something like Prettier
       - name: Lint
-        run: yarn lint
+        run: npm run lint
         continue-on-error: ${{ inputs.allow-lint-errors }}

--- a/.github/workflows/ui-module-descriptor-generate.yml
+++ b/.github/workflows/ui-module-descriptor-generate.yml
@@ -33,7 +33,7 @@ jobs:
           always-auth: true
 
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: npm config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - id: get-version
         name: Get current @folio/stripes-cli version
@@ -45,16 +45,16 @@ jobs:
       - name: Install @folio/stripes-cli
         run: |-
           rm package.json
-          yarn add @folio/stripes-cli@${{ steps.get-version.outputs.version }}
+          npm add @folio/stripes-cli@${{ steps.get-version.outputs.version }}
           git checkout package.json
 
       - name: Set package version number to ${{ inputs.package-version }}
         run: |-
-          yarn config set version-git-tag false
-          yarn version --new-version ${{ inputs.package-version }}
+          npm config set version-git-tag false
+          npm version --new-version ${{ inputs.package-version }}
 
       - name: Generate module descriptor
-        run: yarn --silent stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json
+        run: npx stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json
 
       - name: Print module descriptor
         run: cat module-descriptor.json

--- a/.github/workflows/ui-publish-module.yml
+++ b/.github/workflows/ui-publish-module.yml
@@ -77,8 +77,8 @@ jobs:
 
       - name: Set package version number to ${{ inputs.package-version }}
         run: |-
-          yarn config set version-git-tag false
-          yarn version --new-version ${{ inputs.package-version }}
+          npm config set version-git-tag false
+          npm version --new-version ${{ inputs.package-version }}
 
       - name: Publish package
         run: npm publish

--- a/.github/workflows/ui-tests-bigtest.yml
+++ b/.github/workflows/ui-tests-bigtest.yml
@@ -39,10 +39,10 @@ jobs:
           always-auth: true
 
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: npm config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: npm install --ignore-scripts
 
       - name: Run Bigtest tests
         run: ${{ inputs.bigtest-test-command }}
@@ -62,10 +62,10 @@ jobs:
           path: ${{ inputs.bigtest-coverage-report-dir }}
           retention-days: 5
 
-      - name: Publish yarn.lock
+      - name: Publish package-lock.json
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: yarn.lock
-          path: yarn.lock
-          retention-days: 1
+          name: package-lock.json
+          path: package-lock.json
+          retention-days: 7

--- a/.github/workflows/ui-tests-jest.yml
+++ b/.github/workflows/ui-tests-jest.yml
@@ -39,10 +39,10 @@ jobs:
           always-auth: true
 
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: npm config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: npm install --ignore-scripts
 
       - name: Run Jest tests
         run: ${{ inputs.jest-test-command }}
@@ -66,10 +66,10 @@ jobs:
           path: ${{ inputs.jest-coverage-report-dir }}
           retention-days: 5
 
-      - name: Publish yarn.lock
+      - name: Publish package-lock.json
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: yarn.lock
-          path: yarn.lock
-          retention-days: 1
+          name: package-lock.json
+          path: package-lock.json
+          retention-days: 7

--- a/.github/workflows/ui-translations.yml
+++ b/.github/workflows/ui-translations.yml
@@ -30,7 +30,7 @@ jobs:
           always-auth: true
 
       - name: Set FOLIO NPM registry
-        run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
+        run: npm config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - id: get-version
         name: Get current @folio/stripes-cli version
@@ -40,11 +40,11 @@ jobs:
       - name: Install @folio/stripes-cli
         run: |-
           rm package.json
-          yarn add @folio/stripes-cli@${{ steps.get-version.outputs.version }}
+          npm add @folio/stripes-cli@${{ steps.get-version.outputs.version }}
           git checkout package.json
 
       - name: Compile translations
-        run: yarn stripes translate compile
+        run: npx stripes translate compile
 
       - name: Publish translations
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -3,13 +3,11 @@ name: FOLIO UI Workflows
 on:
   workflow_call:
     inputs:
-      # node/yarn configuration
+      # node/npm configuration
       node-version:
         required: false
         type: string
         default: '20.x'
-      # It should be straightforward to add a customizable Yarn version via a simple `yarn set version 3.x` or similar
-      # https://yarnpkg.com/cli/set/version
       folio-npm-registry:
         required: false
         type: string
@@ -29,7 +27,7 @@ on:
       jest-test-command:
         required: false
         type: string
-        default: yarn test
+        default: npm run test
       jest-junit-output-dir:
         required: false
         type: string
@@ -47,7 +45,7 @@ on:
       bigtest-test-command:
         required: false
         type: string
-        default: yarn test
+        default: npm run test
       bigtest-junit-output-dir:
         required: false
         type: string
@@ -185,7 +183,7 @@ jobs:
           output.write("folio-npm-registry-auth=" + current_npm_registry_auth + "\n")
           output.close()
 
-  # this job is responsible for printing install information and publishing yarn.lock if debug is enabled
+  # this job is responsible for printing install information and publishing package-lock.json if debug is enabled
   install-and-lint:
     name: Install and lint
     needs: [set-shared-variables]

--- a/README-UI.md
+++ b/README-UI.md
@@ -4,7 +4,7 @@
 - [Versioning](#versioning)
 - [Using in your repository](#using-in-your-repository)
 - [Configuration](#configuration)
-  - [Node/Yarn configuration](#nodeyarn-configuration)
+  - [Node/NPM configuration](#nodenpm-configuration)
   - [Linting](#linting)
   - [Unit tests](#unit-tests)
     - [Jest](#jest)
@@ -67,13 +67,13 @@ There are many configuration variables, to allow customization of the workflow t
 if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
 secrets: inherit
 with:
-  jest-test-command: yarn test --ci --color --coverage
+  jest-test-command: npm test --ci --color --coverage
 ```
 
 > [!CAUTION]
 > In general, **it is preferred that you alter your repository to not need to customize the workflow**, particularly for file paths for coverage/etc. This will make it easier to update the workflow in the future, and will help to standardize the CI/CD process across the FOLIO front-end repositories.
 
-### Node/Yarn configuration
+### Node/NPM configuration
 
 | Input                | Type   | Default                                                                                                                 | Description                                    |
 | -------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -95,7 +95,7 @@ Jest, Bigtest, or both can be run as part of the workflow. The default is to run
 | Input                      | Type    | Default                    | Description                                                                                                     |
 | -------------------------- | ------- | -------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `jest-enabled`             | boolean | `true`                     | Whether to run Jest tests                                                                                       |
-| `jest-test-command`        | string  | `yarn test`                | The command to use to run Jest tests                                                                            |
+| `jest-test-command`        | string  | `npm test`                | The command to use to run Jest tests                                                                            |
 | `jest-junit-output-dir`    | string  | `artifacts/jest-junit`     | Directory where Jest reports are stored, without a trailing slash                                               |
 | `jest-coverage-report-dir` | string  | `artifacts/coverage-jest/` | Directory in which Jest coverage reports are stored in, with trailing slash; LCOV data should be in "lcov.info" |
 
@@ -104,7 +104,7 @@ Jest, Bigtest, or both can be run as part of the workflow. The default is to run
 | Input                         | Type    | Default               | Description                                                                                                     |
 | ----------------------------- | ------- | --------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `bigtest-enabled`             | boolean | `false`               | Whether to run Bigtest tests                                                                                    |
-| `bigtest-test-command`        | string  | `yarn test`           | The command to use to run Bigtest tests                                                                         |
+| `bigtest-test-command`        | string  | `npm test`           | The command to use to run Bigtest tests                                                                         |
 | `bigtest-junit-output-dir`    | string  | `artifacts/runTest`   | Directory where Bigtest reports are stored, without a trailing slash                                            |
 | `bigtest-coverage-report-dir` | string  | `artifacts/coverage/` | Directory in which Jest coverage reports are stored in, with trailing slash; LCOV data should be in "lcov.info" |
 


### PR DESCRIPTION
Install with npm v10 (via node v18 or v20) instead of yarn v1. Alternative to PR #31 since yarn v4/corepack are flaky on Windows.

Refs [STRIPES-907](https://folio-org.atlassian.net/browse/STRIPES-907)