### PR TITLE
Only download sonar coverage reports for enabled test suites

### DIFF
--- a/.github/workflows/ui-sonarcloud.yml
+++ b/.github/workflows/ui-sonarcloud.yml
@@ -9,9 +9,15 @@ on:
       sonar-exclusions:
         required: true
         type: string
+      bigtest-enabled:
+        required: true
+        type: boolean
       bigtest-coverage-report-dir:
         required: true
         type: string
+      jest-enabled:
+        required: true
+        type: boolean
       jest-coverage-report-dir:
         required: true
         type: string
@@ -36,6 +42,7 @@ jobs:
 
       - name: Fetch coverage reports (Bigtest)
         uses: actions/download-artifact@v4
+        if: ${{ inputs.bigtest-enabled }}
         with:
           name: bigtest-coverage-report
           path: ${{ inputs.bigtest-coverage-report-dir }}
@@ -43,6 +50,7 @@ jobs:
 
       - name: Fetch coverage reports (Jest)
         uses: actions/download-artifact@v4
+        if: ${{ inputs.jest-enabled }}
         with:
           name: jest-coverage-report
           path: ${{ inputs.jest-coverage-report-dir }}

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -241,7 +241,9 @@ jobs:
     with:
       sonar-sources: ${{ inputs.sonar-sources }}
       sonar-exclusions: ${{ inputs.sonar-exclusions }}
+      bigtest-enabled: ${{ inputs.bigtest-enabled }}
       bigtest-coverage-report-dir: ${{ inputs.bigtest-coverage-report-dir }}
+      jest-enabled: ${{ inputs.jest-enabled }}
       jest-coverage-report-dir: ${{ inputs.jest-coverage-report-dir }}
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
As seen in [this run](https://github.com/folio-org/ui-erm-usage/actions/runs/10769302989), the sonarcloud workflow could report (harmless) warnings if bigtest and/or jest coverage was not available. This checks if they are enabled before attempting to download the coverage reports, eliminating this noise.

![image](https://github.com/user-attachments/assets/edf1d89f-1cc5-4713-a043-2a872c55ef17)
