### PR TITLE
[FOLIO-4077] Freeze lockfile when running yarn install

### DIFF
--- a/.github/workflows/ui-install-and-lint.yml
+++ b/.github/workflows/ui-install-and-lint.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
 
       - name: List installed FOLIO package versions
         run: yarn list --pattern @folio

--- a/.github/workflows/ui-install-and-lint.yml
+++ b/.github/workflows/ui-install-and-lint.yml
@@ -40,8 +40,15 @@ jobs:
       - name: Set FOLIO NPM registry
         run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
 
+        # We must check if a yarn.lock exists, as we do not want to add --frozen-lockfile if there is no lockfile.
+      # Just adding this flag when there is no lockfile would normally cause no issues, however, it will prevent a lockfile
+      # from being generated if one does not exist. This breaks publication of the `yarn.lock` artifact (and use of `yarn list`).
+      - name: Check if lockfile should be frozen
+        id: check-yarn-lock
+        run: echo install-args=$(test -f yarn.lock && echo --frozen-lockfile) | tee -a $GITHUB_OUTPUT
+
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
+        run: yarn install ${{ steps.check-yarn-lock.outputs.install-args }} --ignore-scripts --non-interactive
 
       - name: List installed FOLIO package versions
         run: yarn list --pattern @folio

--- a/.github/workflows/ui-publish-module.yml
+++ b/.github/workflows/ui-publish-module.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ inputs.install-before-publish }}
-        run: yarn install --ignore-scripts --non-interactive
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
 
       - name: Publish package
         run: npm publish

--- a/.github/workflows/ui-tests-bigtest.yml
+++ b/.github/workflows/ui-tests-bigtest.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
 
       - name: Run Bigtest tests
         run: ${{ inputs.bigtest-test-command }}

--- a/.github/workflows/ui-tests-jest.yml
+++ b/.github/workflows/ui-tests-jest.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn config set @folio:registry ${{ inputs.folio-npm-registry }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --non-interactive
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
 
       - name: Run Jest tests
         run: ${{ inputs.jest-test-command }}


### PR DESCRIPTION
Adding `--frozen-lockfile` is safe to do in a non-major change, since it will not affect yarn's behavior if there is no `yarn.lock`