### PR TITLE
FOLIO-4131: Upgrade actions/checkout from 2 or 3 to 4 fixing vulns

### DIFF
--- a/workflow-templates/build-mvn-release.yml
+++ b/workflow-templates/build-mvn-release.yml
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.REF }}
 

--- a/workflow-templates/build-mvn.yml
+++ b/workflow-templates/build-mvn.yml
@@ -31,7 +31,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.REF }}
 

--- a/workflow-templates/folio.yml
+++ b/workflow-templates/folio.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run a one-line script
         run: echo Hello from FOLIO
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4131

actions/checkout@2 and actions/checkout@3 have known vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-21538 cross-spawn ReDoS
* https://www.cve.org/CVERecord?id=CVE-2022-25883  semver ReDoS
* https://app.snyk.io/vuln/SNYK-JS-LODASHSET-1320032  lodash.set Prototype Pollution

Upgrade to version 4 that has fixed them.