### PR TITLE
FOLIO-3203 api-doc: trigger on ModuleDescriptor changes

### DIFF
--- a/workflow-templates/api-doc.yml
+++ b/workflow-templates/api-doc.yml
@@ -32,6 +32,7 @@ on:
     branches: [ main, master ]
     paths:
       - 'src/main/resources/openapi/**'
+      - 'descriptors/ModuleDescriptor-template.json'
     tags: '[vV][0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 


### PR DESCRIPTION
The api-doc Python script consults the ModuleDescriptor to correlate endpoint path with an interface.