### PR TITLE
FOLIO-3994 go-lint: Use specific patch version golangci-lint

### DIFF
--- a/.github/workflows/go-lint-golangci.yml
+++ b/.github/workflows/go-lint-golangci.yml
@@ -36,6 +36,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         # defaults: gosimple govet ineffassign unused
         with:
-          version: v1.63
+          version: v1.63.4
           args: ${{ env.golangci_args }}
 


### PR DESCRIPTION
The golangci-lint-action docs indicate that version can be minor e.g. v1.63

However Workflow run logs show that it is using old v1.62.2

So use a specific patch version e.g. v1.63.4