### PR TITLE
FOLIO-4287: Bump golangci-lint-action to 8, golangci-lint to v2

### DIFF
--- a/.github/workflows/go-lint-golangci.yml
+++ b/.github/workflows/go-lint-golangci.yml
@@ -34,5 +34,7 @@ jobs:
           CONFIG_FILE: ${{ inputs.golangci-config-file }}
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1
 

--- a/.github/workflows/go-lint-golangci.yml
+++ b/.github/workflows/go-lint-golangci.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          # the go version for golangci-lint, not the go version for our module
+          go-version: 'stable'
 
       - name: Checkout folio-org/folio-tools
         uses: actions/checkout@v4
@@ -33,9 +34,5 @@ jobs:
           CONFIG_FILE: ${{ inputs.golangci-config-file }}
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        # defaults: gosimple govet ineffassign unused
-        with:
-          version: v1.63.4
-          args: ${{ env.golangci_args }}
+        uses: golangci/golangci-lint-action@v7
 

--- a/.github/workflows/go-lint-golangci.yml
+++ b/.github/workflows/go-lint-golangci.yml
@@ -36,5 +36,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
+          # The golangci-lint version
           version: v2.1
+          args: ${{ env.golangci_args }}
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4287

In https://github.com/folio-org/.github/blob/v1.9.1/.github/workflows/go-lint-golangci.yml#L36 bump the golangci/golangci-lint-action version from v6 to v7:

https://github.com/golangci/golangci-lint-action

v6 has reached end-of-life on 2025-03-24: https://github.com/golangci/golangci-lint-action

The golangci-lint-action upgrade indirectly upgrades golangci-lint from unsupported v1.63.4 to latest v2 version:
https://github.com/golangci/golangci-lint

This fixes the issue with FOLIO Go modules that get a failure when bumping the go version to 1.24:

> Failed executing command with error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.2)

https://github.com/folio-org/mod-reporting/actions/runs/14796065426/job/41543356880 