### PR TITLE
FOLIO-4126 Add monorepo support to Maven actions

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -66,7 +66,6 @@ jobs:
       - name: Maven build
         run: mvn --update-snapshots clean org.jacoco:jacoco-maven-plugin:prepare-agent install org.jacoco:jacoco-maven-plugin:report
 
-      # todo: tbd if monorepo support required
       - name: Discover maven built apidocs
         id: discover-apidocs
         run: |
@@ -74,7 +73,6 @@ jobs:
             echo "has-maven-apidocs=True" | tee -a $GITHUB_OUTPUT
           fi
 
-      # todo: tbd if monorepo support required
       - name: Upload apidocs as build artifact
         uses: actions/upload-artifact@v6
         if: ${{ steps.discover-apidocs.outputs.has-maven-apidocs == 'True' }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           mkdir -p /tmp/ci-artifacts
           for d in $(find . -type d -name target); do
+            echo "Discovered artifact dir $d"
             mkdir -p "/tmp/ci-artifacts/$(dirname "$d")"
             cp -r "$d" "/tmp/ci-artifacts/$d"
           done

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -90,9 +90,12 @@ jobs:
       - name: Capture build artifacts
         run: |
           mkdir -p /tmp/ci-artifacts
-          cp -r **/target /tmp/ci-artifacts/
+          for d in $(find . -type d -name target); do
+            mkdir -p "/tmp/ci-artifacts/$(dirname "$d")"
+            cp -r "$d" "/tmp/ci-artifacts/$d"
+          done
 
-      - name: Upload all jars as build artifact
+      - name: Upload all jars as a build artifact
         uses: actions/upload-artifact@v6
         with:
           name: built-jars

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: built-jars
-          path: target/**/*.jar
+          path: '**/target/**/*.jar'
           retention-days: 1
 
       - name: Discover maven built apidocs
@@ -93,9 +93,9 @@ jobs:
         with:
           name: build-artifacts
           path: |
-            target
-            !target/**/*.jar
-            !target/apidocs
+            **/target
+            !**/target/**/*.jar
+            !**/target/apidocs
           retention-days: 1
 
       - name: Discover Dockerfile

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -90,11 +90,11 @@ jobs:
       - name: Capture build artifacts
         run: |
           mkdir -p /tmp/ci-artifacts
-          for d in $(find . -type d -name target); do
-            echo "Discovered artifact dir $d"
-            mkdir -p "/tmp/ci-artifacts/$(dirname "$d")"
-            cp -r "$d" "/tmp/ci-artifacts/$d"
-          done
+          find . -type d -name target -exec sh -c '
+            echo "Discovered artifact dir $1"
+            mkdir -p "/tmp/ci-artifacts/$(dirname "$1")"
+            cp -r "$1" "/tmp/ci-artifacts/$1"
+          ' sh {} \;
 
       - name: Upload all jars as a build artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -66,13 +66,7 @@ jobs:
       - name: Maven build
         run: mvn --update-snapshots clean org.jacoco:jacoco-maven-plugin:prepare-agent install org.jacoco:jacoco-maven-plugin:report
 
-      - name: Upload all jars as build artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: built-jars
-          path: '**/target/**/*.jar'
-          retention-days: 1
-
+      # todo: tbd if monorepo support required
       - name: Discover maven built apidocs
         id: discover-apidocs
         run: |
@@ -80,6 +74,7 @@ jobs:
             echo "has-maven-apidocs=True" | tee -a $GITHUB_OUTPUT
           fi
 
+      # todo: tbd if monorepo support required
       - name: Upload apidocs as build artifact
         uses: actions/upload-artifact@v6
         if: ${{ steps.discover-apidocs.outputs.has-maven-apidocs == 'True' }}
@@ -88,14 +83,29 @@ jobs:
           path: target/apidocs
           retention-days: 1
 
+      # monorepo-aware way of doing this. Without the additional directory, upload-artifact will
+      # flatten single `target` dirs, but not in monorepos with multiple `target` dirs. This keeps
+      # everything consistent and ensures the artifact will result in a dir with a `target` and
+      # subfolders with their own `target`s (if applicable).
+      - name: Capture build artifacts
+        run: |
+          mkdir -p /tmp/ci-artifacts
+          cp -r **/target /tmp/ci-artifacts/
+
+      - name: Upload all jars as build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: built-jars
+          path: /tmp/ci-artifacts/**/*.jar
+          retention-days: 1
+
       - name: Upload additional build artifacts
         uses: actions/upload-artifact@v6
         with:
           name: build-artifacts
           path: |
-            **/target
-            !**/target/**/*.jar
-            !**/target/apidocs
+            /tmp/ci-artifacts
+            !/tmp/ci-artifacts/**/*.jar
           retention-days: 1
 
       - name: Discover Dockerfile

--- a/.github/workflows/maven-docker-publish.yml
+++ b/.github/workflows/maven-docker-publish.yml
@@ -89,9 +89,6 @@ jobs:
           name: built-jars
           path: .
 
-      - name: Show contents of target directory
-        run: ls -R target
-
       - name: Prepare the Docker test tag
         id: prepare-docker-test-tag
         run: |

--- a/.github/workflows/maven-docker-publish.yml
+++ b/.github/workflows/maven-docker-publish.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: built-jars
-          path: target
+          path: .
 
       - name: Show contents of target directory
         run: ls -R target

--- a/.github/workflows/maven-module-descriptor-get.yml
+++ b/.github/workflows/maven-module-descriptor-get.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: build-artifacts
           path: .

--- a/.github/workflows/maven-module-descriptor-get.yml
+++ b/.github/workflows/maven-module-descriptor-get.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           name: build-artifacts
+          path: .
 
       - name: Discover ModuleDescriptor
         id: discover-md

--- a/.github/workflows/maven-sonar.yml
+++ b/.github/workflows/maven-sonar.yml
@@ -40,7 +40,7 @@ jobs:
           name: build-artifacts
           path: .
 
-      - run: ls -d **/target
+      - run: ls -d target **/target || true
 
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/maven-sonar.yml
+++ b/.github/workflows/maven-sonar.yml
@@ -38,7 +38,9 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           name: build-artifacts
-          path: target
+          path: .
+
+      - run: ls -d **/target
 
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/maven-sonar.yml
+++ b/.github/workflows/maven-sonar.yml
@@ -40,8 +40,6 @@ jobs:
           name: build-artifacts
           path: .
 
-      - run: ls -d target **/target || true
-
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/maven-sonar.yml
+++ b/.github/workflows/maven-sonar.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
 
       - name: Retrieve build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: build-artifacts
           path: .


### PR DESCRIPTION
This updates the Maven actions to preserve directory structure of monorepo's artifacts, to ensure each subfolder's `target`s can be handled.

There's a little more complexity here as, if `upload-artifact` is passed just a single `target`, it'll flatten the structure and upload everything inside the root `target` but, if in a monorepo and passed multiple `target` and `foo/target`, it'll create a nested directory as expected. To resolve this, we create a temporary `/tmp/ci-artifacts` and do our rearranging there, to ensure the artifact's directory structure always follows the same form.