### PR TITLE
Configure custom settings.xml for Maven build

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -45,13 +45,12 @@ jobs:
           distribution: 'temurin'
 
       - name: Configure custom FOLIO Maven settings.xml
-        run: | 
+        run: |
           mkdir -p ~/.m2
           echo "<settings>
                   <activeProfiles>
                     <activeProfile>folio-gha-repo-order-profile</activeProfile>
                   </activeProfiles>
-
                   <profiles>
                     <profile>
                       <id>folio-gha-repo-order-profile</id>
@@ -68,8 +67,8 @@ jobs:
                         <repository>
                           <id>folio-nexus</id>
                           <name>FOLIO Maven Repository</name>
-	                  <url>https://repository.folio.org/repository/maven-folio</url>
-	                </repository>
+                          <url>https://repository.folio.org/repository/maven-folio</url>
+                        </repository>
                       </repositories>
                     </profile>
                   </profiles>

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -73,7 +73,7 @@ jobs:
                       </repositories>
                     </profile>
                   </profiles>
-                </settings>"
+                </settings>" > ~/.m2/settings.xml
 
       - name: Cache Maven packages
         uses: actions/cache@v5

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -44,6 +44,37 @@ jobs:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
 
+      - name: Configure custom FOLIO Maven settings.xml
+        run: | 
+          mkdir -p ~/.m2
+          echo "<settings>
+                  <activeProfiles>
+                    <activeProfile>folio-gha-repo-order-profile</activeProfile>
+                  </activeProfiles>
+
+                  <profiles>
+                    <profile>
+                      <id>folio-gha-repo-order-profile</id>
+                      <repositories>
+                        <!-- 1. Maven Central First -->
+                        <repository>
+                          <id>central</id>
+                          <name>Maven Central</name>
+                          <url>https://repo.maven.apache.org/maven2/</url>
+                          <releases><enabled>true</enabled></releases>
+                          <snapshots><enabled>false</enabled></snapshots>
+                        </repository>
+                        <!-- 2. FOLIO Repository Second -->
+                        <repository>
+                          <id>folio-nexus</id>
+                          <name>FOLIO Maven Repository</name>
+	                  <url>https://repository.folio.org/repository/maven-folio</url>
+	                </repository>
+                      </repositories>
+                    </profile>
+                  </profiles>
+                </settings>"
+
       - name: Cache Maven packages
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
Because only the folio-nexus repository is explicitly defined as the only Maven repository in the most FOLIO Maven project's POM,  it is the first repository used in when searching for Maven dependencies to download.    Using a custom settings.xml configuration attempts to reverse the Maven search order by checking Maven Central before the FOLIO repository. 