### PR TITLE
FOLIO-4489: docker-publish.yml: Use env var, not var interpolation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,8 +34,10 @@ jobs:
 
     steps:
       - name: Notify whether doing docker push
+        env:
+          DOCKER_PUSH: ${{ inputs.docker-push }}
         run: |
-          if ${{ inputs.docker-push }}; then
+          if [ "$DOCKER_PUSH" = "true" ]; then
             echo "Will do docker build and push, i.e. publish=true" | tee -a $GITHUB_STEP_SUMMARY
           else
             echo "Will do docker build, but will not push, i.e. publish=false" | tee -a $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4489

Note that this also fixes the code injection vulnerability in `if ${{ inputs.docker-push }}; then` where the input is invoked as a shell command.