### PR TITLE
FOLIO-4498: Retry when ModuleDescriptor registry times out

### DIFF
--- a/.github/workflows/go-module-descriptor-publish.yml
+++ b/.github/workflows/go-module-descriptor-publish.yml
@@ -24,13 +24,15 @@ jobs:
           name: ModuleDescriptor.json
 
       - name: Publish ModuleDescriptor
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: ${{ inputs.module-descriptor-registry }}/_/proxy/modules
           method: 'POST'
           contentType: 'application/json; charset=utf-8'
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           timeout: 10000
+          retry: 10
+          retryWait: 21000
           file: ModuleDescriptor.json
           username: ${{ secrets.registry-username }}
           password: ${{ secrets.registry-password }}

--- a/.github/workflows/go-module-descriptor-verify.yml
+++ b/.github/workflows/go-module-descriptor-verify.yml
@@ -38,7 +38,7 @@ jobs:
         run: sleep 10
 
       - name: Pull all module descriptors into Okapi
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: http://${{ steps.okapi-ip.outputs.ip }}:9130/_/proxy/pull/modules
           method: 'POST'
@@ -46,6 +46,8 @@ jobs:
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           data: ${{ inputs.okapi-pull-urls }}
           timeout: 60000
+          retry: 10
+          retryWait: 21000
 
       - name: Download ModuleDescriptor
         uses: actions/download-artifact@v6
@@ -53,11 +55,13 @@ jobs:
           name: ModuleDescriptor.json
 
       - name: Send ModuleDescriptor to Okapi
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: http://${{ steps.okapi-ip.outputs.ip }}:9130/_/proxy/modules
           method: 'POST'
           contentType: 'application/json; charset=utf-8'
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           timeout: 10000
+          retry: 10
+          retryWait: 21000
           file: ModuleDescriptor.json

--- a/.github/workflows/maven-module-descriptor-publish.yml
+++ b/.github/workflows/maven-module-descriptor-publish.yml
@@ -31,6 +31,8 @@ jobs:
           contentType: 'application/json; charset=utf-8'
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           timeout: 10000
+          retry: 10
+          retryWait: 21000
           file: ModuleDescriptor.json
           username: ${{ secrets.registry-username }}
           password: ${{ secrets.registry-password }}

--- a/.github/workflows/maven-module-descriptor-verify.yml
+++ b/.github/workflows/maven-module-descriptor-verify.yml
@@ -46,6 +46,8 @@ jobs:
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           data: ${{ inputs.okapi-pull-urls }}
           timeout: 90000
+          retry: 10
+          retryWait: 21000
 
       - name: Download ModuleDescriptor artifact
         uses: actions/download-artifact@v8
@@ -61,6 +63,8 @@ jobs:
           contentType: 'application/json; charset=utf-8'
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           timeout: 10000
+          retry: 10
+          retryWait: 21000
           file: ModuleDescriptor.json
 
       - name: Show Okapi response

--- a/.github/workflows/ui-module-descriptor-publish.yml
+++ b/.github/workflows/ui-module-descriptor-publish.yml
@@ -34,7 +34,7 @@ jobs:
           path: module-descriptor.json
 
       - name: Publish module descriptor
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: ${{ inputs.module-descriptor-registry }}/_/proxy/modules
           method: 'POST'
@@ -42,5 +42,7 @@ jobs:
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           data: ${{ steps.read-descriptor.outputs.content }}
           timeout: 10000
+          retry: 10
+          retryWait: 21000
           username: ${{ secrets.registry-username }}
           password: ${{ secrets.registry-password }}

--- a/.github/workflows/ui-module-descriptor-verify.yml
+++ b/.github/workflows/ui-module-descriptor-verify.yml
@@ -34,14 +34,16 @@ jobs:
         run: sleep 10
 
       - name: Pull all module descriptors into Okapi
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: http://${{ steps.okapi-ip.outputs.ip }}:9130/_/proxy/pull/modules
           method: 'POST'
           contentType: 'application/json; charset=utf-8'
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           data: ${{ inputs.okapi-pull-contents }}
-          timeout: 60000
+          timeout: 90000
+          retry: 10
+          retryWait: 21000
 
       # from previous step
       - name: Download module descriptor
@@ -57,11 +59,13 @@ jobs:
           path: module-descriptor.json
 
       - name: Post our module
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: http://${{ steps.okapi-ip.outputs.ip }}:9130/_/proxy/modules?preRelease=false&npmSnapshot=false
           method: 'POST'
           contentType: 'application/json; charset=utf-8'
           customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
           timeout: 10000
+          retry: 10
+          retryWait: 21000
           data: ${{ steps.read-descriptor.outputs.content }}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4498

[FOLIO-4472](https://folio-org.atlassian.net/browse/FOLIO-4472) increased the timeout but this hasn’t solved the issue.

The ModuleDescriptor registry still times out. Examples:
* https://github.com/folio-org/mod-settings/actions/runs/24562554947/job/71814781317
* https://github.com/folio-org/mod-settings/actions/runs/24562541031/job/71828328906
* https://github.com/folio-org/mod-settings/actions/runs/24562541031/job/71814804394

Retry on timeout using `retry: 10` and `retryWait: 21000` milliseconds.