### PR TITLE
FOLIO-4489: go-lint-errcheck: Use env var, not ${{...}}, in run: step

### DIFF
--- a/.github/workflows/go-lint-errcheck.yml
+++ b/.github/workflows/go-lint-errcheck.yml
@@ -24,11 +24,7 @@ jobs:
         run: go install github.com/kisielk/errcheck@latest
 
       - name: Run errcheck
-        run: |
-          if ${{ inputs.errcheck-excludes-file != '' }}; then
-            option_errcheck_exclude="-exclude ${{ inputs.errcheck-excludes-file }}"
-          else
-            option_errcheck_exclude=''
-          fi
-          errcheck $option_errcheck_exclude ./...
+        env:
+          EXCLUDE: ${{ inputs.errcheck-excludes-file }}
+        run: errcheck -exclude "$EXCLUDE" ./...
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4489

In
https://github.com/folio-org/.github/blob/master/.github/workflows/go-lint-errcheck.yml
replace the var interpolation `${{...}}` in the `run:` step, instead
use an env var and always pass an (empty or non-empty) `-exclude` argument:

    -exclude "$EXCLUDE"

errcheck properly handles an empty `-exclude` argument:
https://github.com/kisielk/errcheck/blob/v1.10.0/main.go#L210