### PR TITLE
FOLIO-4501: Bump golangci-lint 2.6 -> 2.11, avoid go-golangci-lint-args.sh

### DIFF
--- a/.github/workflows/go-lint-golangci.yml
+++ b/.github/workflows/go-lint-golangci.yml
@@ -21,22 +21,10 @@ jobs:
           # the go version for golangci-lint, not the go version for our module
           go-version: 'stable'
 
-      - name: Checkout folio-org/folio-tools
-        uses: actions/checkout@v6
-        with:
-          repository: folio-org/folio-tools
-          path: folio-tools
-          fetch-depth: 1
-
-      - name: Determine golangci-lint arguments
-        run: echo golangci_args=$(./folio-tools/github-actions-scripts/go-golangci-lint-args.sh) | tee -a $GITHUB_ENV
-        env:
-          CONFIG_FILE: ${{ inputs.golangci-config-file }}
-
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           # The golangci-lint version
-          version: v2.6
-          args: ${{ env.golangci_args }}
+          version: v2.11
+          args: --config=${{ inputs.golangci-config-file }} --disable errcheck --disable staticcheck --enable gosec
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4501

Issue 1:

https://github.com/folio-org/.github/blob/master/.github/workflows/go-lint-golangci.yml fails with

> panic: file requires newer Go version go1.26 (application built with go1.25) [recovered, repanicked]

because the golangci-lint version 2.6 (released 2025-11) doesn’t support go1.26:

https://github.com/folio-org/mod-reporting/actions/runs/24454497150/job/71451510004

Solution: Bump golangci-lint from 2.6 to 2.11.

Issue 2:

https://github.com/folio-org/.github/blob/master/.github/workflows/go-lint-golangci.yml uses a convoluted way to create the golangci-lint parameters:

* Check out folio-tools
* From folio-tools execute a single (!) file: https://github.com/folio-org/folio-tools/blob/master/github-actions-scripts/go-golangci-lint-args.sh
* go-golangci-lint-args.sh suppresses the --config argument if no config file has been passed

These steps are not needed.

GitHub Action expressions can suppress the --config parameter (if this were needed, see below), this avoids external scripts:

```
        env:
          CONFIG: ${{ case(inputs.golangci-config-file == '', '', format('--config={0}', inputs.golangci-config-file)) }}
        with:
          args: ${{ env.CONFIG }} --disable errcheck --disable staticcheck --enable gosec
```

However, golangci-lint properly handles `--config=` without nothing after the `=` by using the default.

Solution:

```
          args: --config=${{ inputs.golangci-config-file }} --disable errcheck --disable staticcheck --enable gosec
```