### PR TITLE
FOLIO-4502: Bump staticcheck 2025.1 to 2026.1 in go-lint-staticcheck.yml

### DIFF
--- a/.github/workflows/go-lint-staticcheck.yml
+++ b/.github/workflows/go-lint-staticcheck.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1
         with:
-          version: "2025.1"
+          version: "2026.1"
           install-go: false


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4502

In https://github.com/folio-org/.github/blob/master/.github/workflows/go-lint-staticcheck.yml
bump https://github.com/dominikh/go-tools/releases
from [Staticcheck 2025.1 (v0.6.0)](https://github.com/dominikh/go-tools/releases/tag/2025.1)
to [Staticcheck 2026.1 (v0.7.0)](https://github.com/dominikh/go-tools/releases/tag/2026.1).

This adds improved Go 1.25 and Go 1.26 support.