### PR TITLE
FOLIO-4506 Fail release builds when lockfiles pin snapshot dependencies

### DIFF
--- a/.github/workflows/ui-install-and-lint.yml
+++ b/.github/workflows/ui-install-and-lint.yml
@@ -17,6 +17,11 @@ on:
       allow-lint-errors:
         required: true
         type: boolean
+      # release validation
+      fail-on-snapshot-deps:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   run:
@@ -51,6 +56,16 @@ jobs:
 
       - name: List installed FOLIO package versions
         run: yarn list --pattern @folio
+
+      # Snapshots resolve from the npm-folioci repository; released versions resolve from npm-folio.
+      # This job installs with yarn classic, so any npm-folioci "resolved" URL in yarn.lock is a snapshot.
+      - name: Fail on snapshot dependencies
+        if: inputs.fail-on-snapshot-deps
+        run: |
+          if grep -nE '^\s+resolved "https?://[^"]*npm-folioci' yarn.lock; then
+            echo "::error file=yarn.lock::yarn.lock contains snapshot (npm-folioci) resolutions - regenerate against npm-folio before releasing"
+            exit 1
+          fi
 
       - name: Publish yarn.lock
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -207,6 +207,8 @@ jobs:
       folio-npm-registry: ${{ needs.set-shared-variables.outputs.folio-npm-registry }}
       allow-lint-errors: ${{ inputs.allow-lint-errors }}
       yarn-lock-retention-days: ${{ inputs.yarn-lock-retention-days }}
+      # On release tags, fail if the lockfile still pins snapshots from npm-folioci.
+      fail-on-snapshot-deps: ${{ needs.set-shared-variables.outputs.is-release == 'True' }}
 
   jest-tests:
     name: Run Jest tests


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4506

## Purpose

Release builds must not ship with snapshot dependencies pinned in `yarn.lock`. Snapshot versions resolve from the `npm-folioci` repository, whereas released versions resolve from `npm-folio`. If a release tag is built against a lockfile that still references `npm-folioci`, the resulting artifact depends on non-released FOLIO packages. This change prevents such releases from succeeding by failing the UI install-and-lint workflow when snapshot resolutions are detected on a release tag.

## Approach

- Added an optional `fail-on-snapshot-deps` input to `ui-install-and-lint.yml` that, when true, greps `yarn.lock` for `npm-folioci` resolutions and fails the job if any are found.
- Wired `ui.yml` to pass `fail-on-snapshot-deps: true` only when `is-release` is `True`.