### PR TITLE
FOLIO-4126 Enable java-version=25 for upcoming Umbrellaleaf

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -175,8 +175,8 @@ jobs:
 
       - name: Ensure Java version
         run: |
-          if [ "${{ inputs.java-version }}" != "17" ] && [ "${{ inputs.java-version }}" != "21" ]; then
-            echo "java-version=${{ inputs.java-version }}: Must be '17' or '21'."
+          if [ "${{ inputs.java-version }}" != "17" ] && [ "${{ inputs.java-version }}" != "21" ] && [ "${{ inputs.java-version }}" != "25" ]; then
+            echo "java-version=${{ inputs.java-version }}: Must be '17' or '21' or '25'."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * (Add more progress summary items here.)
 
+## [1.16.1](https://github.com/folio-org/.github/tree/v1.16.1) (2026-05-21)
+[Full Changelog](https://github.com/folio-org/.github/compare/v1.16.0...v1.16.1)
+
+* FOLIO-4126 Enable java-version=25 for upcoming Umbrellaleaf - in #158
+
 ## [1.16.0](https://github.com/folio-org/.github/tree/v1.16.0) (2026-05-20)
 [Full Changelog](https://github.com/folio-org/.github/compare/v1.15.3...v1.16.0)
 

--- a/README-maven.md
+++ b/README-maven.md
@@ -77,6 +77,8 @@ For example:
 
 ### Configuration: java-version
 
+Allowed values: 17 or 21 or 25
+
 Optional. Default = '21'
 
 ```yaml


### PR DESCRIPTION
Ready for upcoming Umbrellaleaf. Default is still 21